### PR TITLE
fix: revert build.gradle sourceSets changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,11 +149,13 @@ run {
 }
 
 sourceSets {
-  main {
-    resources {
-      srcDirs = ["config"]
-      includes = ["**/*.yml"]
-    }
+  javaRestTest {
+    compileClasspath += sourceSets["main"].output + sourceSets["test"].output + configurations["testRuntimeClasspath"]
+    runtimeClasspath += output + compileClasspath
+  }
+  yamlRestTest {
+    compileClasspath += sourceSets["main"].output + sourceSets["test"].output + configurations["testRuntimeClasspath"]
+    runtimeClasspath += output + compileClasspath
   }
 }
 


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Enables running the plugin in debug and non debug mode locally. Without this change we get a null pointer exception because `fstore-index-mapping.json` in resources is not accessible .

### Issues Resolved
Will be created

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
