### PR TITLE
2.10 fix double start

### DIFF
--- a/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
+++ b/src/main/java/com/o19s/es/ltr/feature/store/StoredLtrModel.java
@@ -198,6 +198,11 @@ public class StoredLtrModel implements StorableElement {
     }
 
     @Override
+    public boolean isFragment() {
+        return false;// since toXContent already have enclosing start/endObject braces
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof StoredLtrModel)) return false;


### PR DESCRIPTION
this fixes `StoredLtrModelParserTests#testToXContent` at least to me. 
I understand this test failure, but hardly can guess what's changed between versions. So, it's just a demonstration, not a prescription. 

ok I have just two failures 
```
Tests with failures:
 - com.o19s.es.ltr.feature.store.StoredFeatureSetParserTests.testToXContent
 - com.o19s.es.ltr.logging.LoggingSearchExtBuilderTests.testToXContent
```
nd they seem like can be healed by the same approach. 